### PR TITLE
Fix for Issue #72

### DIFF
--- a/TidyChat/TidyChat.cs
+++ b/TidyChat/TidyChat.cs
@@ -64,7 +64,7 @@ public sealed class TidyChat : IDalamudPlugin
         if (Configuration.InstanceInDtrBar)
             dtrEntry = DtrBar.Get(Name);
 
-        ChatGui.ChatMessage += OnChat;
+        ChatGui.CheckMessageHandled += OnChat;
         ClientState.TerritoryChanged += OnTerritoryChanged;
         ClientState.Login += OnLogin;
         ClientState.Logout += OnLogout;
@@ -97,7 +97,7 @@ public sealed class TidyChat : IDalamudPlugin
         CommandManager.RemoveHandler(SettingsCommand);
         CommandManager.RemoveHandler(ShorthandCommand);
         PluginInterface.LanguageChanged -= UpdateLang;
-        ChatGui.ChatMessage -= OnChat;
+        ChatGui.CheckMessageHandled -= OnChat;
         ClientState.TerritoryChanged -= OnTerritoryChanged;
         ClientState.Login -= OnLogin;
         ClientState.Logout -= OnLogout;


### PR DESCRIPTION
Hello there 👋 

Issue #72 has been marked as closed, but someone mentioned that [Pet Nicknames](https://github.com/Glyceri/FFXIVPetRenamer) breaks Tidy Chat in the exact same way as Issue #72 does.

Relevant here is the [Dalamud Sourcecode](https://github.com/goatcorp/Dalamud/blob/b5696afe94b9ace8c58323a751b5bb88cae9cece/Dalamud/Game/Gui/ChatGui.cs#L282).

Personally, I have no clue why this happens, as the [ref keyword](https://github.com/goatcorp/Dalamud/blob/b5696afe94b9ace8c58323a751b5bb88cae9cece/Dalamud/Game/Gui/ChatGui.cs#L319) is used and that exact value gets send to the next plugin afterwards. But only the last plugin that sets isHandled for a chat messages gets taken into account causing heaps of issues.
However, Dalamud has a seperate; earlier; [call ](https://github.com/goatcorp/Dalamud/blob/b5696afe94b9ace8c58323a751b5bb88cae9cece/Dalamud/Game/Gui/ChatGui.cs#L303)that is specifically used for isHandled. 

My fix is to move Tidy Chat from ChatMessage to CheckMessageHandled.

(The real fix would be to fix this issue in Dalamud, but I'm not touching that)