### PR TITLE
fix #96

### DIFF
--- a/TidyChat/Configuration.cs
+++ b/TidyChat/Configuration.cs
@@ -40,7 +40,9 @@ public class Configuration : IPluginConfiguration
 
     public T? GetPropertyValue<T>(object obj, string propName)
     {
-        return (T?)obj?.GetType()?.GetProperty(propName)?.GetValue(this, index: null);
+        var prop = obj.GetType().GetProperty(propName);
+        if (prop == null) return default;
+        return (T?)prop.GetValue(this, index: null);
     }
 
     public void Save()

--- a/TidyChat/TidyChatPlugin.cs
+++ b/TidyChat/TidyChatPlugin.cs
@@ -287,7 +287,7 @@ public sealed class TidyChatPlugin : IDalamudPlugin
         {
             if (rule.Error is not null)
             {
-                Log.Debug($"Error: {rule.Error}");
+                Log.Error($"Error: {rule.Error}");
             }
 
             // Skip rules that wouldn't change isBlocked away from defaultBlocked


### PR DESCRIPTION
In your last big update you changed the config name of `ShowUsedEmotes` and didn't migrate the config so the old value stuck and thus every single action the plugin took it'd error out and would create immense log spam.

A few notes:

1)
```
// If we don't know if a rule is True or False assume it is True
```

Not sure why this is an assumption. It seems you can only not know if the rule doesn't exist, so assuming it's true does nothing. I haven't spent the time in your code base you have so maybe this makes sense somehow.

2) I changed that rule.error to actually log in the error level because I didn't even notice the stack trace until I was looking in the debug log for another plugin entirely.

3) This could be handled by just removing unmatched properties (either when checked or on load) too but I didn't want to change your config.

4) is the plugin being maintained outside of bare minimum patch maintenance?