### PR TITLE
Fix DTR Entry

### DIFF
--- a/TidyChat/Configuration.cs
+++ b/TidyChat/Configuration.cs
@@ -49,7 +49,7 @@ public class Configuration : IPluginConfiguration
     {
         pluginInterface!.SavePluginConfig(this);
         Rules.UpdateIsActiveStates(this);
-        TidyChatPlugin.InstanceDtrBarUpdate(TidyChatPlugin.GetDtrBar(), this);
+        TidyChatPlugin.InstanceDtrBarUpdate(this);
     }
 
     #region Chat Filters


### PR DESCRIPTION
The "display current instance in DTR bar" setting currently doesn't seem to be working, and seems to occasionally be printing null pointer exceptions in the log.

It looks like this might've been broken in 55a3499 as part of the API 11 bump, where the DtrEntry variable no longer got set.

While I was at it, I also added using the `Hidden` attribute when the DTR entry is not shown, which bypasses some of the rendering, and also added a tooltip so when you hover over the instance it says "TidyChat", since this fix might mean that people who had this setting enabled might suddenly get a new instance number in the DTR bar and not realise where it is from.