### PR TITLE
Use Dalamud window system

### DIFF
--- a/TidyChat/Settings/TabFooter.cs
+++ b/TidyChat/Settings/TabFooter.cs
@@ -6,7 +6,7 @@ namespace TidyChat;
 
 public static class TabFooter
 {
-    public static void Display(Configuration configuration, ref bool settingsVisible)
+    public static bool Display(Configuration configuration)
     {
         ImGui.Spacing();
         ImGui.Separator();
@@ -16,7 +16,7 @@ public static class TabFooter
         if (ImGui.Button(Languages.SettingsTabFooter_SaveAndCloseButtonText))
         {
             configuration.Save();
-            settingsVisible = false;
+            return true;
         }
 
         if (!configuration.NoCoffee)
@@ -47,5 +47,7 @@ public static class TabFooter
                 UseShellExecute = true,
             });
         ImGui.PopStyleColor(3);
+
+        return false;
     }
 }

--- a/TidyChat/TidyChatPlugin.cs
+++ b/TidyChat/TidyChatPlugin.cs
@@ -11,6 +11,7 @@ using Dalamud.Game.Gui.Dtr;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
+using Dalamud.Interface.Windowing;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
@@ -38,6 +39,7 @@ public sealed class TidyChatPlugin : IDalamudPlugin
 
     private Configuration Configuration { get; }
     private PluginUI PluginUi { get; }
+    private readonly WindowSystem WindowSystem = new WindowSystem("TidyChat");
 
     private const string SettingsCommand = TidyStrings.SettingsCommand;
     private const string ShorthandCommand = TidyStrings.ShorthandCommand;
@@ -64,6 +66,7 @@ public sealed class TidyChatPlugin : IDalamudPlugin
         ClientState.Logout += OnLogout;
 
         PluginUi = new PluginUI(Configuration);
+        WindowSystem.AddWindow(PluginUi);
 
         CommandManager.AddHandler(SettingsCommand, new CommandInfo(OnCommand)
         {
@@ -897,7 +900,7 @@ public sealed class TidyChatPlugin : IDalamudPlugin
 
     private void OnCommand(string command, string args)
     {
-        PluginUi.SettingsVisible = true;
+        PluginUi.IsOpen = true;
     }
 
     private void UpdateLang(string langCode)
@@ -907,12 +910,12 @@ public sealed class TidyChatPlugin : IDalamudPlugin
 
     private void DrawUI()
     {
-        PluginUi.Draw();
+        WindowSystem.Draw();
     }
 
     private void DrawConfigUI()
     {
-        PluginUi.SettingsVisible = true;
+        PluginUi.IsOpen = true;
     }
 
     #region Chat2 ChatTypes


### PR DESCRIPTION
Using the Dalamud window system adds some benefits such as closing automatically when pressing Esc.

This also fixes an ImGui assert on ImGui.SetNextWindowSize, since you cannot combine ImGuiConds with |, it's meant to be used an enum instead of bitflags. I'm not entirely sure if Appearing or FirstUseEver is the desired value here, but I picked FirstUseEver since it's the closest to the current behaviour.

(If you're not interested in switching to the new window system, I can also send a PR with just the assertion fix)